### PR TITLE
Added MinGW support

### DIFF
--- a/src/binary_io/binary_io.cpp
+++ b/src/binary_io/binary_io.cpp
@@ -92,7 +92,13 @@ namespace binary_io
 			{
 				std::size_t read = 0;
 #if BINARY_IO_OS_WINDOWS
-#ifndef __MINGW32__
+#if __MINGW32__
+				read = std::fread(
+					a_dst.data(),
+					1,
+					a_dst.size_bytes(),
+					a_stream);
+#else
 				read = ::fread_s(
 					a_dst.data(),
 					a_dst.size_bytes(),

--- a/src/binary_io/binary_io.cpp
+++ b/src/binary_io/binary_io.cpp
@@ -92,12 +92,14 @@ namespace binary_io
 			{
 				std::size_t read = 0;
 #if BINARY_IO_OS_WINDOWS
+#ifndef __MINGW32__
 				read = ::fread_s(
 					a_dst.data(),
 					a_dst.size_bytes(),
 					1,
 					a_dst.size_bytes(),
 					a_stream);
+#endif
 #else
 				read = std::fread(
 					a_dst.data(),


### PR DESCRIPTION
This basically makes it so if `__MINGW32__` is defined, it won't use `fread_s`